### PR TITLE
herokuのドメインを変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  host = 'https://mysterious-thicket-75747.herokuapp.com'
+  host = 'https://former-colleagues-sample-app.herokuapp.com/'
+  # host = 'https://mysterious-thicket-75747.herokuapp.com'
   config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
     :address        => 'smtp.sendgrid.net',


### PR DESCRIPTION
デプロイ先のhttps://former-colleagues-sample-app.herokuapp.com にドメインを変更